### PR TITLE
Special handling for empty strings

### DIFF
--- a/redisgraph_bulk_loader/entity_file.py
+++ b/redisgraph_bulk_loader/entity_file.py
@@ -73,6 +73,11 @@ def typed_prop_to_binary(prop_val, prop_type):
         # TODO This is not allowed in Cypher, consider how to handle it here rather than in-module.
         return struct.pack(format_str, 0)
 
+    if prop_val == "<<EMPTY>>" and prop_type in {Type.ID_STRING, Type.STRING}:
+        # Handle empty strings as valid string values
+        encoded_str = b"\x00"  # Explicitly encode as an empty string with a null terminator
+        return struct.pack(format_str + "%ds" % len(encoded_str), Type.STRING.value, encoded_str)
+
     if prop_type == Type.ID_INTEGER or prop_type == Type.LONG:
         try:
             numeric_prop = int(prop_val)


### PR DESCRIPTION
The current implementation of the redisgraph-bulk-loader does not handle empty strings as it doesn't differentiate between an empty string and a property value that does not exist when reading the csvfile.

The simplest solution here seemed to be setting property values that should be `= ""` to `<<EMPTY>>` and having the bulk loader make sure that it writes the a binary encoded empty string when creating a new graph. All non existent property values will be treated as NULL.